### PR TITLE
Change tags variable type from list to map

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,5 +3,5 @@ variable "location" {}
 variable "name" {}
 
 variable "tags" {
-  type = "list"
+  type = "map"
 }


### PR DESCRIPTION
According to official documentation tags are map but not list type:

https://www.terraform.io/docs/providers/azurerm/r/resource_group.html